### PR TITLE
Add a png.lib file on windows

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -29,4 +29,9 @@ if errorlevel 1 exit 1
 copy %LIBRARY_LIB%\libpng16_static.lib %LIBRARY_LIB%\libpng_static.lib
 if errorlevel 1 exit 1
 
+:: matplotlib (and others?) expect a different name, which is also in the
+:: original libpng package in the defaults channel
+copy %LIBRARY_LIB%\libpng16.lib %LIBRARY_LIB%\png.lib
+if errorlevel 1 exit 1
+
 copy %RECIPE_DIR%\libpng-LICENSE.txt %SRC_DIR%\libpng-LICENSE.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: b36a3c124622c8e1647f360424371394284f4c6c4b384593e478666c59ff42d3
 
 build:
-    number: 1
+    number: 2
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]


### PR DESCRIPTION
matplotlib expects the lib under that name, so add it as well. The file is also
in the package from the defaults channel, so this could also be considered a
regression against that version.

See https://github.com/matplotlib/matplotlib/issues/6460 for the discussion on
that topic.
