### PR TITLE
Update to version 1.6.28

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.6.26" %}
+{% set version = "1.6.28" %}
 
 package:
   name: libpng
@@ -6,8 +6,8 @@ package:
 
 source:
   fn: libpng-{{ version }}.tar.gz
-  url: ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng16/libpng-{{ version }}.tar.gz
-  sha256: 81bfc8f16ed125622c0c5ad44eeffda19e7a7c7e32f47e43c8932bf32deae7cc
+  url: http://download.sourceforge.net/libpng/libpng-{{ version }}.tar.gz
+  md5: 897ccec1ebfb0922e83c2bfaa1be8748
 
 build:
   number: 0


### PR DESCRIPTION
ref conda-forge/libpng-feedstock#12

* Security vulnerability for 1.6.26 exists.
* have moved download domain to sourceforge, as simplesystems doesn't
keep older versions around.
* changed to md5, as those are published by libpng author's.