### PR TITLE
Add png.lib to Windows

### DIFF
--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -39,3 +39,5 @@ if errorlevel 1 exit 1
 copy %LIBRARY_LIB%\libpng16_static.lib %LIBRARY_LIB%\png16_static.lib
 if errorlevel 1 exit 1
 
+copy %LIBRARY_LIB%\libpng.lib %LIBRARY_LIB%\png.lib
+if errorlevel 1 exit 1

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -16,7 +16,7 @@ source:
     - patches/0002-Ensure-that-lm-is-not-included-in-Windows-pkg-config.patch
 
 build:
-  number: 0
+  number: 1
   skip:
     - win and vc<14
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -40,6 +40,9 @@ requirements:
 
 tests:
   - package_contents:
+      files:
+        - if: win
+          then: Library/lib/png.lib
       lib:
         - if: win
           then: libpng${{ short_version }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This adds `png.lib`. There is already `libpng.lib` and this adds the same library, but without the "lib" prefix.